### PR TITLE
Added support for "exclude" attribute in Apparatus Entry for Collation view

### DIFF
--- a/src/app/components/apparatus-entry/apparatus-entry-detail/apparatus-entry-detail.component.html
+++ b/src/app/components/apparatus-entry/apparatus-entry-detail/apparatus-entry-detail.component.html
@@ -4,7 +4,7 @@
             <div class="row">
                 <div class="col text-truncate">
                     <span class="fw-bold me-1">{{ data.exponent }}</span>
-                    <evt-reading class="info-rdg" *ngIf="data.lemma; else criticalContent"
+                    <evt-reading class="info-rdg" *ngIf="this.showLemma; else criticalContent"
                         [data]="data.lemma"></evt-reading>
                     <ng-template #criticalContent>
                         <span class="me-1" *ngFor="let content of data.criticalContent">
@@ -19,16 +19,21 @@
             </div>
             <div class="row">
                 <div class="col">
-                    <div class="d-flex align-items-start" *ngFor="let readingItem of readingItems">
-                        <div class="info-rdg pe-2 fw-semibold">
+                    <div class="d-flex align-items-center" *ngFor="let readingItem of readingItems">
+                        <div class="info-rdg pe-2 fw-semibold align-self-start">
                             <evt-reading *ngIf="readingItem.reading.content.length !== 0"
                                 [data]="readingItem.reading"></evt-reading>
-                            <span *ngIf="readingItem.reading.content.length === 0" class="font-italic">{{'omit' |
-                                translate}}</span>
+                            <span *ngIf="readingItem.reading.content.length === 0" class="font-italic">{{'omit' | translate}}</span>
                         </div>
                         <span *ngIf="readingItem.reading.attributes.wit" class="d-block">
                             <evt-witness-metadata
                                 [witnessMetadata]="readingItem.reading.attributes.wit"></evt-witness-metadata>
+                        </span>
+                        <span *ngIf="readingItem.reading.excludedWitIDs.length">
+                            <span class="fw-bold ps-3">Exclude: </span>
+                            <ng-container *ngFor="let excludedWitId of readingItem.reading.excludedWitIDs">
+                               <evt-witness-id [witnessId]="excludedWitId"></evt-witness-id>
+                            </ng-container>
                         </span>
                     </div>
                 </div>
@@ -51,14 +56,14 @@
     <div class="card-footer app-detail-tabs">
         <ul ngbNav #appEntryTab="ngbNav" class="nav-pills" (click)="$event.stopPropagation()">
             <li ngbNavItem="criticalNotes" *ngIf="data.notes.length > 0">
-                <a class="app-detail-btn" ngbNavLink (click)="onTabClicked('criticalNotes')">{{'criticalNotes' |
+                <a class="app-detail-btn" [class.active]="this.currentTab === 'criticalNotes'" ngbNavLink (click)="onTabClicked('criticalNotes')">{{'criticalNotes' |
                     translate}}</a>
                 <ng-template ngbNavContent>
                     <evt-note *ngFor="let note of data.notes" [data]="note"></evt-note>
                 </ng-template>
             </li>
             <li ngbNavItem="notSignificantRdg" *ngIf="this.notSignificantReadings.length > 0">
-                <a class="app-detail-btn" ngbNavLink
+                <a class="app-detail-btn" ngbNavLink [class.active]="this.currentTab === 'ortographicVariants'"
                     (click)="onTabClicked('ortographicVariants')">{{'ortographicVariants' | translate}}</a>
                 <ng-template ngbNavContent>
                     <span class="d-block" *ngFor="let el of this.notSignificantReadings">
@@ -69,7 +74,7 @@
             </li>
 
             <li ngbNavItem="corrSeq" *ngIf="data.changes.length > 0">
-                <a class="source-detail-btn" ngbNavLink (click)="onTabClicked('corrSeq')">{{'corrSeq' | translate}}</a>
+                <a class="source-detail-btn" [class.active]="this.currentTab === 'corrSeq'" ngbNavLink (click)="onTabClicked('corrSeq')">{{'corrSeq' | translate}}</a>
                 <ng-template ngbNavContent>
                     <evt-mod-sequence [data]="data.changes" [orderedLayers]="orderedLayers"
                         [selectedLayer]="selectedLayer">
@@ -77,8 +82,8 @@
                 </ng-template>
             </li>
 
-            <li ngbNavItem="info">
-                <a class="app-detail-btn" ngbNavLink (click)="onTabClicked('info')">{{'info' | translate}}</a>
+            <li ngbNavItem="info"> 
+                <a class="app-detail-btn" [class.active]="this.currentTab === 'info'" ngbNavLink (click)="onTabClicked('info')">{{'info' | translate}}</a>
                 <ng-template ngbNavContent>
                     <ng-container *ngFor="let readingItem of readingItems">
                         <div class="mb-2">
@@ -112,7 +117,8 @@
                             </span>
                             <ng-container *ngFor="let metadata of readingItem.reading.attributes | keyvalue">
                                 <span class="d-block" *ngIf="metadata.key !== 'wit'">
-                                    <span class="info-label">{{ metadata.key }}:</span> {{ metadata.value }}
+                                    <span class="info-label">{{ metadata.key }}:</span> 
+                                    <evt-witness-metadata [witnessMetadata]="metadata.value"></evt-witness-metadata> 
                                 </span>
                             </ng-container>
                         </div>
@@ -121,7 +127,7 @@
             </li>
 
             <li ngbNavItem="xml">
-                <a class="app-detail-btn" ngbNavLink (click)="onTabClicked('xml')">{{'xml' | translate}}</a>
+                <a class="app-detail-btn" [class.active]="this.currentTab === 'xml'" ngbNavLink (click)="onTabClicked('xml')">{{'xml' | translate}}</a>
                 <ng-template ngbNavContent>
                     <evt-original-encoding-viewer
                         [originalEncoding]="data.originalEncoding"></evt-original-encoding-viewer>

--- a/src/app/components/apparatus-entry/apparatus-entry-detail/apparatus-entry-detail.component.ts
+++ b/src/app/components/apparatus-entry/apparatus-entry-detail/apparatus-entry-detail.component.ts
@@ -5,6 +5,7 @@ import { EVTModelService } from '../../../services/evt-model.service';
 import { distinctUntilChanged } from 'rxjs';
 import { EVTStatusService } from 'src/app/services/evt-status.service';
 import { ApparatusEntryDetailService } from './apparatus-entry-detail.service';
+import { WitnessPanelService } from 'src/app/panels/witness-panel/witness-panel.service';
 
 
 @Component({
@@ -36,16 +37,19 @@ export class ApparatusEntryDetailComponent implements OnInit, OnDestroy {
   public get isTabContentExpanded(): boolean {
     return this.currentTab !== undefined;
   }
-  private currentTab: AppTabType = undefined;
+  currentTab: AppTabType = undefined;
 
   getLayerData(changeData: ChangeLayerData) {
     this.orderedLayers = changeData?.layerOrder;
   }
 
+  showLemma: boolean = false;
+
   constructor(
     public evtModelService: EVTModelService,
     public evtStatusService: EVTStatusService,
     private apparatusEntryDetailService: ApparatusEntryDetailService,
+    private witnessPanelService: WitnessPanelService,
   ) {
   }
 
@@ -63,6 +67,8 @@ export class ApparatusEntryDetailComponent implements OnInit, OnDestroy {
     this.readingItems = readings.filter(rdg => !!rdg).map((rdg, i) => {
       return { reading: rdg, isFirst: i === 0, isLemma: rdg.class === 'lem' }
     });
+    const isWitnessExcluded = this.data.isWitnessExcluded(this.witnessPanelService.witnessId);
+    this.showLemma = !!this.data.lemma && !isWitnessExcluded;
   }
 
   ngOnDestroy() {
@@ -99,6 +105,7 @@ export class ApparatusEntryDetailComponent implements OnInit, OnDestroy {
       this.currentTab = tab;
     }
   }
+
 }
 
 export interface ReadingItem {

--- a/src/app/components/apparatus-entry/apparatus-entry-readings/apparatus-entry-readings.component.html
+++ b/src/app/components/apparatus-entry/apparatus-entry-readings/apparatus-entry-readings.component.html
@@ -12,9 +12,9 @@
     </ng-container>
     <span>] </span>
 </span>
-<span class="app-entry-reading" *ngFor="let el of significantRdg">
-    <evt-reading *ngIf="el.content.length !== 0" [data]="el" [selectedLayer]="selectedLayer"></evt-reading>
-    <span class="font-italic" *ngIf="el.content.length === 0">omit.</span>
+<span class="app-entry-reading" *ngFor="let reading of significantReading">
+    <evt-reading *ngIf="reading.content.length !== 0" [data]="reading" [selectedLayer]="selectedLayer"></evt-reading>
+    <span class="font-italic" *ngIf="reading.content.length === 0">omit.</span>
     <!-- TODO: handle lacunastart and lacunaend -->
      
     <!-- <ng-container *ngFor="let witID of el.witIDs">

--- a/src/app/components/apparatus-entry/apparatus-entry-readings/apparatus-entry-readings.component.ts
+++ b/src/app/components/apparatus-entry/apparatus-entry-readings/apparatus-entry-readings.component.ts
@@ -23,8 +23,9 @@ export class ApparatusEntryReadingsComponent {
   ) {
   }
 
-  get significantRdg(): Reading[] {
-    return this.data.readings.filter((rdg) => rdg?.significant);
+  get significantReading(): Reading[] {
+    const result = this.data.readings.filter((rdg) => rdg?.significant);
+    return result;
   }
 
   // getWits$(witID: string): Observable<string[]> {

--- a/src/app/components/apparatus-entry/apparatus-entry.component.ts
+++ b/src/app/components/apparatus-entry/apparatus-entry.component.ts
@@ -61,8 +61,10 @@ export class ApparatusEntryComponent implements OnInit {
   ngOnInit(): void {
     this.isInWitnessPanel = !!this.witnessPanelService;
     if (this.isInWitnessPanel) {
-      this.selectedReading = this.data.orderedReadings
-        .find(r => r.witIDs.includes(this.witnessPanelService.witnessId) || r.witIDs.some(x => this.witnessPanelService.anchestorsIds.includes(x)));
+      const isWitnessExcluded = this.data.isWitnessExcluded(this.witnessPanelService.witnessId);
+      this.selectedReading = isWitnessExcluded ? this.data.lemma : this.data.orderedReadings
+        .find(r => r.witIDs.includes(this.witnessPanelService.witnessId) 
+        || r.witIDs.some(x => this.witnessPanelService.anchestorsIds.includes(x)));
     }
   }
 

--- a/src/app/components/reading/reading.component.ts
+++ b/src/app/components/reading/reading.component.ts
@@ -20,8 +20,8 @@ export class ReadingComponent extends Highlightable {
 
   getLayerColor(changeLayer) {
     const layerColors = AppConfig.evtSettings.edition.changeSequenceView.layerColors;
-    if ((changeLayer) && (layerColors[changeLayer.replace('#','')])) {
-      return layerColors[changeLayer.replace('#','')];
+    if ((changeLayer) && (layerColors[changeLayer.replace('#', '')])) {
+      return layerColors[changeLayer.replace('#', '')];
     }
 
     return 'black';

--- a/src/app/models/evt-models.ts
+++ b/src/app/models/evt-models.ts
@@ -219,6 +219,11 @@ export class ApparatusEntry extends GenericElement {
     additionalAttributes: AdditionalAttributes;
     criticalContent: ParseResult<GenericElement>[];
     exponent: string;
+
+    isWitnessExcluded(witnessId: string): boolean {
+        const isWitnessExcluded = this.readings.some(x => x.excludedWitIDs.includes(witnessId));
+        return isWitnessExcluded;
+    }
 }
 
 export class AdditionalAttributes {
@@ -323,6 +328,7 @@ export class Analogue extends GenericElement {
 export class Reading extends GenericElement {
     id: string;
     witIDs: string[];
+    excludedWitIDs: string [];
     significant: boolean;
     varSeq?: number;
 }

--- a/src/app/services/xml-parsers/app-parser.ts
+++ b/src/app/services/xml-parsers/app-parser.ts
@@ -18,6 +18,7 @@ export class RdgParser extends EmptyParser implements Parser<XMLElement> {
             id: getID(rdg),
             attributes: this.attributeParser.parse(rdg),
             witIDs: this.parseReadingWitnesses(rdg) || [],
+            excludedWitIDs: this.parseExcludedWitnesses(rdg),
             content: this.parseAppReadingContent(rdg),
             significant: this.isReadingSignificant(rdg),
             class: rdg.tagName.toLowerCase(),
@@ -29,6 +30,13 @@ export class RdgParser extends EmptyParser implements Parser<XMLElement> {
         return rdg.getAttribute('wit')?.split('#')
             .map((el) => removeSpaces(el))
             .filter((el) => el.length !== 0);
+    }
+
+    private parseExcludedWitnesses(rdg: XMLElement) {
+        const result = rdg.getAttribute('exclude')?.split('#')
+            .map((el) => removeSpaces(el))
+            .filter((el) => el.length !== 0);
+        return result ?? [];
     }
 
     private parseAppReadingContent(rdg: XMLElement) {
@@ -116,7 +124,8 @@ export class AppParser extends EmptyParser implements Parser<XMLElement> {
             changes: (lemma !== undefined) ? this.orderChanges(allReadings, lemma) : [],
             orderedReadings: Array.from(allReadings).sort((r1, r2) => r1.varSeq - r2.varSeq),
             additionalAttributes: new AdditionalAttributes(),
-            exponent: ''
+            exponent: '',
+            isWitnessExcluded: ApparatusEntry.prototype.isWitnessExcluded
         };
     }
 


### PR DESCRIPTION
In the collation view, when the text is constructed for a witness, if such witness is excluded in a reading, then the critical text/lemma will be shown in the text.